### PR TITLE
Set final name for easier add-on creation process

### DIFF
--- a/dirigera-client-mqtt/pom.xml
+++ b/dirigera-client-mqtt/pom.xml
@@ -40,6 +40,7 @@
     </dependencies>
 
     <build>
+        <finalName>dirigera-client-mqtt</finalName>
         <plugins>
             <plugin>
                 <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Set a final name for the artifact without version number.
This will make creating the add-on easier