### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,20 +105,27 @@ This application reads the data model of your DIRIGERA and outputs it as JSON. B
 we can determine at which points the API data model deviates or is 
 incomplete. You may submit the generated dump as an issue to GitHub.
 
-#### Build and run the Dump Application
-1) Clone repository:
-```bash
-git clone git@github.com:dvdgeisler/DirigeraClient.git
-cd DirigeraClient
-```
-2) Build project:
-```bash
-./mvnw package
-```
-3) Run the Dump-Application:
-```bash
-java -jar ./dirigera-client-dump/target/dirigera-client-dump.jar --dirigera.hostname=<DIRIGERA-IP-ADDRESS>
-```
+#### Run the Dump Application
+##### Prerequisites:
+* Java 17 (or higher) has to be installed
+  * Download Java the latest OpenJDK for your operating system [here](https://openjdk.org)
+  * Unpack the zip file to a location of your choosing
+  * Add `JAVA_HOME` to your environment variables with the following path `<PATH_TO_UNPACKED_ZIP_FILE>`
+  * Add `%JAVA_HOME%\bin` to your path variable
+  * Reboot your pc
+  * Execute `java -version`
+    * This should output something like:
+    ```
+      openjdk version "17.0.2" 2022-01-18
+      OpenJDK Runtime Environment (build 17.0.2+8-86)
+      OpenJDK 64-Bit Server VM (build 17.0.2+8-86, mixed mode, sharing)
+    ```
+* DIRIGERA Gateway is connected to the internet
+  * Find the IP address of your DIRIGERA Gateway in your router.
+
+##### Instructions
+1) Download the latest [dirigera-client-dump.jar](https://github.com/dvdgeisler/DirigeraClient/releases)
+2) Run `java -jar dirigira-client-dump.jar --dirigera.hostname=<ip address of DIRIGERA Gateway>`
 
 ## Integration to Home Assistant
 


### PR DESCRIPTION
I saw the PR that should have been an issue.

Due to the addition of the automated release process, users no longer need to built the dump application (we do it for them)
So I updated the readme with instructions on how to run it and how to install the prerequisites (Only Java in this case) 