### PR TITLE
Basic MQTTS support

### DIFF
--- a/dirigera-client-mqtt/src/main/java/de/dvdgeisler/iot/dirigera/client/mqtt/DirigeraClientMqttApplication.java
+++ b/dirigera-client-mqtt/src/main/java/de/dvdgeisler/iot/dirigera/client/mqtt/DirigeraClientMqttApplication.java
@@ -42,6 +42,7 @@ public class DirigeraClientMqttApplication implements MqttCallback {
                                     @Value("${dirigera.mqtt.port:1883}") final Short port,
                                     @Value("${dirigera.mqtt.username:}") final String username,
                                     @Value("${dirigera.mqtt.password:}") final String password,
+                                    @Value("${dirigera.mqtt.use-ssl:false}") final Boolean useSsl,
                                     @Value("${dirigera.mqtt.reconnect:true}") final Boolean reconnect,
                                     @Value("${dirigera.mqtt.timeout:0}") final Integer timeout,
                                     @Value("${dirigera.mqtt.keep-alive:2}") final Integer keepAliveInterval,
@@ -55,7 +56,7 @@ public class DirigeraClientMqttApplication implements MqttCallback {
         publisherId = api.status().map(s -> s.id).block();
         options = new MqttConnectOptions();
 
-        if (port == 8883) {
+        if (useSsl) {
             uri = String.format("ssl://%s:%d", host, port);
             options.setSocketFactory(SSLSocketFactory.getDefault());
         } else {
@@ -64,8 +65,8 @@ public class DirigeraClientMqttApplication implements MqttCallback {
 
         client = new MqttClient(uri, publisherId);
 
-        log.info("Connect to MQTT broker: host={}, port={}, publisherId={}, reconnect={}, timeout={}",
-                host, port, publisherId, reconnect, timeout);
+        log.info("Connect to MQTT broker: host={}, port={}, publisherId={}, reconnect={}, timeout={}, useSsl={}",
+                host, port, publisherId, reconnect, timeout, useSsl);
 
         options.setKeepAliveInterval(keepAliveInterval);
         options.setMaxReconnectDelay(reconnectDelay);

--- a/dirigera-client-mqtt/src/main/java/de/dvdgeisler/iot/dirigera/client/mqtt/DirigeraClientMqttApplication.java
+++ b/dirigera-client-mqtt/src/main/java/de/dvdgeisler/iot/dirigera/client/mqtt/DirigeraClientMqttApplication.java
@@ -14,6 +14,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
+import javax.net.ssl.SSLSocketFactory;
 
 @SpringBootApplication
 @ComponentScan(basePackageClasses = {
@@ -52,13 +53,20 @@ public class DirigeraClientMqttApplication implements MqttCallback {
         final String uri;
 
         publisherId = api.status().map(s -> s.id).block();
-        uri = String.format("tcp://%s:%d", host, port);
+        options = new MqttConnectOptions();
+
+        if (port == 8883) {
+            uri = String.format("ssl://%s:%d", host, port);
+            options.setSocketFactory(SSLSocketFactory.getDefault());
+        } else {
+            uri = String.format("tcp://%s:%d", host, port);
+        }
+
         client = new MqttClient(uri, publisherId);
 
         log.info("Connect to MQTT broker: host={}, port={}, publisherId={}, reconnect={}, timeout={}",
                 host, port, publisherId, reconnect, timeout);
 
-        options = new MqttConnectOptions();
         options.setKeepAliveInterval(keepAliveInterval);
         options.setMaxReconnectDelay(reconnectDelay);
         options.setAutomaticReconnect(reconnect);


### PR DESCRIPTION
In my current setup, my MQTT broker is only exposing an MQTTS port(8883). It is using a let's encrypt SSL certificate so using a default SSLSocketFactory is enough for my purpose.

Added new boolean option: `dirigera.mqtt.use-ssl`. Default is `false`. If provided, the `ssl://` will be used and initialized the default SSL context. Override the `dirigera.mqtt.port` to point to your MQTTs endpoint, typical port is 8883.

Tested it locally by directly launching the mqtt jar app, see the log message below(redacted some info and to reduce the verbosity):

```
> java -jar dirigera-client-mqtt.jar --dirigera.hostname=dirigera.local --dirigera.mqtt.hostname=mqtt.local --dirigera.mqtt.port=8883 --logging.level.root=INFO --dirigera.port=8443 --dirigera.mqtt.use-ssl=true

...
2023-04-07 11:56:53.956  INFO 3403 --- [           main] .d.i.d.c.m.DirigeraClientMqttApplication : Starting DirigeraClientMqttApplication v0.0.1-SNAPSHOT using Java 17.0.5 on ...
2023-04-07 11:56:53.958 DEBUG 3403 --- [           main] .d.i.d.c.m.DirigeraClientMqttApplication : Running with Spring Boot v2.7.5, Spring v5.3.23
2023-04-07 11:56:53.958  INFO 3403 --- [           main] .d.i.d.c.m.DirigeraClientMqttApplication : No active profile set, falling back to 1 default profile: "default"
...
2023-04-07 11:56:54.552  INFO 3403 --- [           main] d.d.i.d.client.api.http.TokenStore       : Load access token
2023-04-07 11:56:54.859  INFO 3403 --- [           main] d.d.i.d.client.api.http.ClientOAuthApi   : Dirigera client name: ...
2023-04-07 11:56:54.879  INFO 3403 --- [oundedElastic-1] d.d.i.dirigera.client.api.WebSocketApi   : Start event handler thread: id=30, name=boundedElastic-1
2023-04-07 11:56:55.533  INFO 3403 --- [oundedElastic-2] d.d.i.d.client.api.http.ClientApi        : Start ping thread: id=64, name=boundedElastic-2
2023-04-07 11:56:55.633  INFO 3403 --- [           main] .d.i.d.c.m.DirigeraClientMqttApplication : Connect to MQTT broker: host=mqtt.local, port=8883, publisherId=1c6ed993-ba70-4853-bb8d-a9fc3ad3132d_1, reconnect=true, timeout=0, useSsl=true
2023-04-07 11:56:56.136  INFO 3403 --- [           main] .d.i.d.c.m.DirigeraClientMqttApplication : Connection to MQTT broker successfully established
2023-04-07 11:56:56.139  INFO 3403 --- [           main] d.d.i.d.client.mqtt.MqttEventHandler     : Subscribe HassLightDeviceEventHandler to Dirigera websocket: event=DeviceEvent
2023-04-07 11:56:56.476 DEBUG 3403 --- [           main] d.d.i.d.client.mqtt.MqttEventHandler     : Publish to MQTT: topic=homeassistant/light/1c...
2023-04-07 11:56:56.485 DEBUG 3403 --- [           main] d.d.i.d.client.mqtt.MqttEventHandler     : Subscribe to MQTT topic: topic=homeassistant/...
2023-04-07 11:56:56.493 DEBUG 3403 --- [           main] d.d.i.d.client.mqtt.MqttEventHandler     : Publish to MQTT: topic=homeassistant/light/1c...
2023-04-07 11:56:56.501 DEBUG 3403 --- [           main] d.d.i.d.client.mqtt.MqttEventHandler     : Publish to MQTT: topic=homeassistant/light/1c...
2023-04-07 11:56:56.510 DEBUG 3403 --- [           main] d.d.i.d.client.mqtt.MqttEventHandler     : Publish to MQTT: topic=homeassistant/light/1c...
2023-04-07 11:56:56.518 DEBUG 3403 --- [           main] d.d.i.d.client.mqtt.MqttEventHandler     : Subscribe to MQTT topic: topic=homeassistant/...
2023-04-07 11:56:56.520 DEBUG 3403 --- [           main] d.d.i.d.client.mqtt.MqttEventHandler     : Publish to MQTT: topic=homeassistant/light/1c...
2023-04-07 11:56:56.527 DEBUG 3403 --- [           main] d.d.i.d.client.mqtt.MqttEventHandler     : Publish to MQTT: topic=homeassistant/light/1c...
2023-04-07 11:56:56.538  INFO 3403 --- [           main] d.d.i.d.client.mqtt.MqttEventHandler     : Subscribe HassBlindsDeviceEventHandler to Dirigera websocket: event=DeviceEvent
2023-04-07 11:56:56.561  INFO 3403 --- [           main] d.d.i.d.client.mqtt.MqttEventHandler     : Subscribe HassMotionSensorDeviceEventHandler to Dirigera websocket: event=DeviceEvent
2023-04-07 11:56:56.580  INFO 3403 --- [           main] d.d.i.d.client.mqtt.MqttEventHandler     : Subscribe HassOutletDeviceEventHandler to Dirigera websocket: event=DeviceEvent
...
```