### PR TITLE
Set availability payload to pure string instead of json

### DIFF
--- a/dirigera-client-mqtt/src/main/java/de/dvdgeisler/iot/dirigera/client/mqtt/MqttEventHandler.java
+++ b/dirigera-client-mqtt/src/main/java/de/dvdgeisler/iot/dirigera/client/mqtt/MqttEventHandler.java
@@ -42,12 +42,13 @@ public abstract class MqttEventHandler<E extends Event> {
     }
 
     protected <T> void publish(final String topic, final T payload, final int qos, final boolean retained) {
-        final String json;
+        publishString(topic, this.toJSON(payload), qos, retained);
+    }
 
-        json = this.toJSON(payload);
+    protected void publishString(final String topic, final String payload, final int qos, final boolean retained) {
         try {
-            log.debug("Publish to MQTT: topic={}, payload={}, qos={}, retained={}", topic, json, qos, retained);
-            this.mqtt.publish(topic, json.getBytes(StandardCharsets.UTF_8), qos, retained);
+            log.debug("Publish to MQTT: topic={}, payload={}, qos={}, retained={}", topic, payload, qos, retained);
+            this.mqtt.publish(topic, payload.getBytes(StandardCharsets.UTF_8), qos, retained);
         } catch (MqttException e) {
             log.error("Error while publishing to MQTT topic: {}", e.getMessage());
         }
@@ -55,6 +56,10 @@ public abstract class MqttEventHandler<E extends Event> {
 
     protected <T> void publish(final String topic, final T payload) {
         this.publish(topic, payload, 1, true);
+    }
+
+    protected void publishString(final String topic, final String payload) {
+        this.publishString(topic, payload, 1, true);
     }
 
     protected <T> void subscribe(final String topic, final Class<T> payloadType, final Consumer<T> consumer) {

--- a/dirigera-client-mqtt/src/main/java/de/dvdgeisler/iot/dirigera/client/mqtt/hass/HassAirPurifierEventHandler.java
+++ b/dirigera-client-mqtt/src/main/java/de/dvdgeisler/iot/dirigera/client/mqtt/hass/HassAirPurifierEventHandler.java
@@ -59,8 +59,8 @@ public class HassAirPurifierEventHandler extends HassDeviceEventHandler<AirPurif
 
         config.availability = new DeviceAvailability();
         config.availability.topic = this.getTopic(device, HASS_COMPONENT, TOPIC_AVAILABILITY);
-        config.availability.payload_available = this.toJSON(DeviceAvailabilityState.ONLINE);
-        config.availability.payload_not_available = this.toJSON(DeviceAvailabilityState.OFFLINE);
+        config.availability.payload_available = DeviceAvailabilityState.ONLINE.toString();
+        config.availability.payload_not_available = DeviceAvailabilityState.OFFLINE.toString();
         this.publish(this.getTopic(device, HASS_COMPONENT, TOPIC_CONFIG), config);
 
         this.subscribe(
@@ -80,12 +80,12 @@ public class HassAirPurifierEventHandler extends HassDeviceEventHandler<AirPurif
         getState(device).ifPresent(state ->
                 this.publish(this.getTopic(device, HASS_COMPONENT, TOPIC_STATE), state));
         getAvailability(device).ifPresent(s ->
-                this.publish(this.getTopic(device, HASS_COMPONENT, TOPIC_AVAILABILITY), s));
+                this.publishString(this.getTopic(device, HASS_COMPONENT, TOPIC_AVAILABILITY), s.toString()));
     }
 
     @Override
     protected void onDeviceRemoved(final AirPurifierDevice device) {
-        this.publish(this.getTopic(device, HASS_COMPONENT, TOPIC_AVAILABILITY), DeviceAvailabilityState.OFFLINE);
+        this.publishString(this.getTopic(device, HASS_COMPONENT, TOPIC_AVAILABILITY), DeviceAvailabilityState.OFFLINE.toString());
         this.publish(this.getTopic(device, HASS_COMPONENT, TOPIC_REMOVE), null);
         this.unsubscribe(this.getTopic(device, HASS_COMPONENT, TOPIC_SET));
     }

--- a/dirigera-client-mqtt/src/main/java/de/dvdgeisler/iot/dirigera/client/mqtt/hass/HassBlindsDeviceEventHandler.java
+++ b/dirigera-client-mqtt/src/main/java/de/dvdgeisler/iot/dirigera/client/mqtt/hass/HassBlindsDeviceEventHandler.java
@@ -63,8 +63,8 @@ public class HassBlindsDeviceEventHandler extends HassDeviceEventHandler<BlindsD
 
         config.availability = new DeviceAvailability();
         config.availability.topic = this.getTopic(device, HASS_COMPONENT, TOPIC_AVAILABILITY);
-        config.availability.payload_available = this.toJSON(DeviceAvailabilityState.ONLINE);
-        config.availability.payload_not_available = this.toJSON(DeviceAvailabilityState.OFFLINE);
+        config.availability.payload_available = DeviceAvailabilityState.ONLINE.toString();
+        config.availability.payload_not_available = DeviceAvailabilityState.OFFLINE.toString();
         this.publish(this.getTopic(device, HASS_COMPONENT, TOPIC_CONFIG), config);
 
         this.subscribe(
@@ -86,12 +86,12 @@ public class HassBlindsDeviceEventHandler extends HassDeviceEventHandler<BlindsD
         getPosition(device).ifPresent(position ->
                 this.publish(this.getTopic(device, HASS_COMPONENT, TOPIC_POSITION), position));
         getAvailability(device).ifPresent(s ->
-                this.publish(this.getTopic(device, HASS_COMPONENT, TOPIC_AVAILABILITY), s));
+                this.publishString(this.getTopic(device, HASS_COMPONENT, TOPIC_AVAILABILITY), s.toString()));
     }
 
     @Override
     protected void onDeviceRemoved(final BlindsDevice device) {
-        this.publish(this.getTopic(device, HASS_COMPONENT, TOPIC_AVAILABILITY), DeviceAvailabilityState.OFFLINE);
+        this.publishString(this.getTopic(device, HASS_COMPONENT, TOPIC_AVAILABILITY), DeviceAvailabilityState.OFFLINE.toString());
         this.publish(this.getTopic(device, HASS_COMPONENT, TOPIC_REMOVE), null);
         this.unsubscribe(this.getTopic(device, HASS_COMPONENT, TOPIC_SET));
     }

--- a/dirigera-client-mqtt/src/main/java/de/dvdgeisler/iot/dirigera/client/mqtt/hass/HassEnvironmentSensorEventHandler.java
+++ b/dirigera-client-mqtt/src/main/java/de/dvdgeisler/iot/dirigera/client/mqtt/hass/HassEnvironmentSensorEventHandler.java
@@ -66,8 +66,8 @@ public class HassEnvironmentSensorEventHandler extends HassDeviceEventHandler<En
       config.availability = new DeviceAvailability();
       config.availability.topic = this.getTopic(device, HASS_COMPONENT, TOPIC_AVAILABILITY);
 
-      config.availability.payload_available = this.toJSON(DeviceAvailabilityState.ONLINE);
-      config.availability.payload_not_available = this.toJSON(DeviceAvailabilityState.OFFLINE);
+      config.availability.payload_available = DeviceAvailabilityState.ONLINE.toString();
+      config.availability.payload_not_available = DeviceAvailabilityState.OFFLINE.toString();
       this.publish(this.getTopic(device, HASS_COMPONENT, TOPIC_CONFIG), config);
       this.onDeviceStateChanged(device);
    }
@@ -86,12 +86,12 @@ public class HassEnvironmentSensorEventHandler extends HassDeviceEventHandler<En
       getVocIndex(device).ifPresent(value ->
                this.publish(this.getTopic(device, HASS_COMPONENT, TOPIC_VOCINDEX), value));
       getAvailability(device).ifPresent(s ->
-               this.publish(this.getTopic(device, HASS_COMPONENT, TOPIC_AVAILABILITY), s));
+               this.publishString(this.getTopic(device, HASS_COMPONENT, TOPIC_AVAILABILITY), s.toString()));
    }
 
    @Override
    protected void onDeviceRemoved(EnvironmentSensorDevice device) {
-      this.publish(this.getTopic(device, HASS_COMPONENT, TOPIC_AVAILABILITY), DeviceAvailabilityState.OFFLINE);
+      this.publishString(this.getTopic(device, HASS_COMPONENT, TOPIC_AVAILABILITY), DeviceAvailabilityState.OFFLINE.toString());
       this.publish(this.getTopic(device, HASS_COMPONENT, TOPIC_REMOVE), null);
       this.unsubscribe(this.getTopic(device, HASS_COMPONENT, TOPIC_SET));
    }

--- a/dirigera-client-mqtt/src/main/java/de/dvdgeisler/iot/dirigera/client/mqtt/hass/HassLightDeviceEventHandler.java
+++ b/dirigera-client-mqtt/src/main/java/de/dvdgeisler/iot/dirigera/client/mqtt/hass/HassLightDeviceEventHandler.java
@@ -71,8 +71,8 @@ public class HassLightDeviceEventHandler extends HassDeviceEventHandler<LightDev
 
         config.availability = new DeviceAvailability();
         config.availability.topic = this.getTopic(device, HASS_COMPONENT, TOPIC_AVAILABILITY);
-        config.availability.payload_available = this.toJSON(DeviceAvailabilityState.ONLINE);
-        config.availability.payload_not_available = this.toJSON(DeviceAvailabilityState.OFFLINE);
+        config.availability.payload_available = DeviceAvailabilityState.ONLINE.toString();
+        config.availability.payload_not_available = DeviceAvailabilityState.OFFLINE.toString();
         this.publish(this.getTopic(device, HASS_COMPONENT, TOPIC_CONFIG), config);
 
         this.subscribe(this.getTopic(device, HASS_COMPONENT, TOPIC_SET),
@@ -133,12 +133,12 @@ public class HassLightDeviceEventHandler extends HassDeviceEventHandler<LightDev
                 status);
 
         getAvailability(device).ifPresent(s ->
-                this.publish(this.getTopic(device, HASS_COMPONENT, TOPIC_AVAILABILITY), s));
+                this.publishString(this.getTopic(device, HASS_COMPONENT, TOPIC_AVAILABILITY), s.toString()));
     }
 
     @Override
     protected void onDeviceRemoved(final LightDevice device) {
-        this.publish(this.getTopic(device, HASS_COMPONENT, TOPIC_AVAILABILITY), DeviceAvailabilityState.OFFLINE);
+        this.publishString(this.getTopic(device, HASS_COMPONENT, TOPIC_AVAILABILITY), DeviceAvailabilityState.OFFLINE.toString());
         this.publish(this.getTopic(device, HASS_COMPONENT, TOPIC_REMOVE), null);
     }
 

--- a/dirigera-client-mqtt/src/main/java/de/dvdgeisler/iot/dirigera/client/mqtt/hass/HassOutletDeviceEventHandler.java
+++ b/dirigera-client-mqtt/src/main/java/de/dvdgeisler/iot/dirigera/client/mqtt/hass/HassOutletDeviceEventHandler.java
@@ -49,8 +49,8 @@ public class HassOutletDeviceEventHandler extends HassDeviceEventHandler<OutletD
 
         config.availability = new DeviceAvailability();
         config.availability.topic = this.getTopic(device, HASS_COMPONENT, TOPIC_AVAILABILITY);
-        config.availability.payload_available = this.toJSON(DeviceAvailabilityState.ONLINE);
-        config.availability.payload_not_available = this.toJSON(DeviceAvailabilityState.OFFLINE);
+        config.availability.payload_available = DeviceAvailabilityState.ONLINE.toString();
+        config.availability.payload_not_available = DeviceAvailabilityState.OFFLINE.toString();
         this.publish(this.getTopic(device, HASS_COMPONENT, TOPIC_CONFIG), config);
 
         this.subscribe(
@@ -73,12 +73,12 @@ public class HassOutletDeviceEventHandler extends HassDeviceEventHandler<OutletD
         getState(device).ifPresent(state ->
                 this.publish(this.getTopic(device, HASS_COMPONENT, TOPIC_STATE), state));
         getAvailability(device).ifPresent(s ->
-                this.publish(this.getTopic(device, HASS_COMPONENT, TOPIC_AVAILABILITY), s));
+                this.publishString(this.getTopic(device, HASS_COMPONENT, TOPIC_AVAILABILITY), s.toString()));
     }
 
     @Override
     protected void onDeviceRemoved(final OutletDevice device) {
-        this.publish(this.getTopic(device, HASS_COMPONENT, TOPIC_AVAILABILITY), DeviceAvailabilityState.OFFLINE);
+        this.publishString(this.getTopic(device, HASS_COMPONENT, TOPIC_AVAILABILITY), DeviceAvailabilityState.OFFLINE.toString());
         this.publish(this.getTopic(device, HASS_COMPONENT, TOPIC_REMOVE), null);
     }
 


### PR DESCRIPTION
- Before this change the payload_available/payload_not_available was set to a json string, and thus the the configuration json had a json within the json (quoted strings). This PR set the availabilty to be only just a string.